### PR TITLE
Add basic Go backend with MinIO and Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+S3_ENDPOINT=http://s3:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=inventory

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore environment files
+.env
+
+# Build artifacts
+web/backend/server
+
+# Go build cache
+bin/
+obj/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# inventory-ui-s3
+# Inventory UI S3
+
+This project provides a simple Go backend that stores and retrieves a `table.json` file from an S3 compatible storage (MinIO). It is orchestrated using Docker Compose.
+
+## Usage
+
+1. Copy `.env.example` to `.env` and adjust credentials if needed.
+2. Run `docker-compose up --build` to start the backend and MinIO services.
+3. Access the backend at `http://localhost:8080` and MinIO console at `http://localhost:9001` (default credentials are from `.env`).
+
+The backend exposes two endpoints:
+
+- `GET /table` – retrieve `table.json` from the configured bucket
+- `PUT /table` – upload a new `table.json` to the bucket
+
+If the configured bucket does not exist, it is created on startup. The backend exits with an error log if it cannot connect to the S3 service.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: ./web/backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    volumes:
+      - ./web/backend:/app
+    depends_on:
+      - s3
+  s3:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - s3data:/data
+volumes:
+  s3data:

--- a/web/backend/Dockerfile
+++ b/web/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.20-alpine
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o server ./
+EXPOSE 8080
+CMD ["/app/server"]

--- a/web/backend/go.mod
+++ b/web/backend/go.mod
@@ -1,0 +1,10 @@
+module backend
+
+go 1.20
+
+require (
+    github.com/gorilla/mux v1.8.1
+    github.com/joho/godotenv v1.4.0
+    github.com/minio/minio-go/v7 v7.0.25
+)
+

--- a/web/backend/handlers/table.go
+++ b/web/backend/handlers/table.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/minio/minio-go/v7"
+)
+
+type TableHandler struct {
+	Client *minio.Client
+	Bucket string
+}
+
+func (h *TableHandler) GetTable(w http.ResponseWriter, r *http.Request) {
+	obj, err := h.Client.GetObject(r.Context(), h.Bucket, "table.json", minio.GetObjectOptions{})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer obj.Close()
+	data, err := io.ReadAll(obj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+func (h *TableHandler) PutTable(w http.ResponseWriter, r *http.Request) {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+	_, err = h.Client.PutObject(r.Context(), h.Bucket, "table.json",
+		bytes.NewReader(data), int64(len(data)), minio.PutObjectOptions{ContentType: "application/json"})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/web/backend/main.go
+++ b/web/backend/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+
+	"backend/handlers"
+)
+
+func initS3() (*minio.Client, string, error) {
+	if err := godotenv.Load(); err != nil {
+		log.Println("No .env file found, relying on environment variables")
+	}
+	endpoint := os.Getenv("S3_ENDPOINT")
+	accessKey := os.Getenv("S3_ACCESS_KEY")
+	secretKey := os.Getenv("S3_SECRET_KEY")
+	bucket := os.Getenv("S3_BUCKET")
+
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure: false,
+	})
+	if err != nil {
+		return nil, bucket, err
+	}
+
+	exists, err := client.BucketExists(context.Background(), bucket)
+	if err != nil {
+		return nil, bucket, err
+	}
+	if !exists {
+		if err := client.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{}); err != nil {
+			return nil, bucket, err
+		}
+	}
+	return client, bucket, nil
+}
+
+func main() {
+	client, bucket, err := initS3()
+	if err != nil {
+		log.Fatalf("Failed to connect to S3: %v", err)
+	}
+
+	h := &handlers.TableHandler{Client: client, Bucket: bucket}
+	r := mux.NewRouter()
+	r.HandleFunc("/table", h.GetTable).Methods(http.MethodGet)
+	r.HandleFunc("/table", h.PutTable).Methods(http.MethodPut)
+
+	log.Println("Starting server on :8080")
+	if err := http.ListenAndServe(":8080", r); err != nil {
+		log.Fatalf("Server error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- scaffold Go backend with MinIO support
- add Dockerfile and docker-compose setup to run backend and MinIO
- include `.env.example` with S3 configuration
- implement GET/PUT handlers for `table.json`
- document usage in README

## Testing
- `go build ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_688340ebc7608323bd10d076ef08969e