### PR TITLE
Add React frontend and Docker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ web/backend/server
 # Go build cache
 bin/
 obj/
+
+# Node
+web/frontend/node_modules/
+web/frontend/build/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Inventory UI S3
 
-This project provides a simple Go backend that stores and retrieves a `table.json` file from an S3 compatible storage (MinIO). It is orchestrated using Docker Compose.
+This project provides a React frontend and a Go backend that store and retrieve table data from an S3 compatible storage (MinIO). Everything is orchestrated using Docker Compose.
 
 ## Usage
 
 1. Copy `.env.example` to `.env` and adjust credentials if needed.
-2. Run `docker-compose up --build` to start the backend and MinIO services.
-3. Access the backend at `http://localhost:8080` and MinIO console at `http://localhost:9001` (default credentials are from `.env`).
+2. Run `docker-compose up --build` to start the backend, frontend and MinIO services.
+3. Access the frontend at `http://localhost:3000`, the backend at `http://localhost:8080` and the MinIO console at `http://localhost:9001` (default credentials are from `.env`).
 
 The backend exposes two endpoints:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,16 @@ services:
       - ./web/backend:/app
     depends_on:
       - s3
+  frontend:
+    build:
+      context: ./web/frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_API_URL=http://backend:8080
+    depends_on:
+      - backend
   s3:
     image: minio/minio:latest
     environment:

--- a/web/frontend/.dockerignore
+++ b/web/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/web/frontend/Dockerfile
+++ b/web/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine as build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY public ./public
+COPY src ./src
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@mui/icons-material": "^5.14.0",
+    "@mui/material": "^5.14.0",
+    "@mui/x-data-grid": "^6.14.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject"
+  }
+}

--- a/web/frontend/public/index.html
+++ b/web/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Inventory UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { AppBar, Tabs, Tab, Box, Container } from '@mui/material';
+import TabPanel from './components/TabPanel';
+
+const tabNames = ['ceph', 'kubernetes', 'openshift'];
+
+export default function App() {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ mt: 4 }}>
+      <AppBar position="static">
+        <Tabs value={value} onChange={handleChange} textColor="inherit" indicatorColor="secondary">
+          {tabNames.map((name) => (
+            <Tab label={name} key={name} />
+          ))}
+        </Tabs>
+      </AppBar>
+      {tabNames.map((name, idx) => (
+        <TabPanel key={name} value={value} index={idx} name={name} />
+      ))}
+    </Container>
+  );
+}

--- a/web/frontend/src/components/TabPanel.jsx
+++ b/web/frontend/src/components/TabPanel.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import TableView from './TableView';
+
+export default function TabPanel({ value, index, name }) {
+  return (
+    <div role="tabpanel" hidden={value !== index}">
+      {value === index && (
+        <Box sx={{ p: 3 }}>
+          <TableView tableName={name} />
+        </Box>
+      )}
+    </div>
+  );
+}

--- a/web/frontend/src/components/TableView.jsx
+++ b/web/frontend/src/components/TableView.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { Box, Button, TextField, CircularProgress, Alert } from '@mui/material';
+
+const API_BASE = process.env.REACT_APP_API_URL || '';
+
+export default function TableView({ tableName }) {
+  const [rows, setRows] = useState([]);
+  const [columns, setColumns] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [filterText, setFilterText] = useState('');
+
+  const fetchData = useCallback(() => {
+    setLoading(true);
+    fetch(`${API_BASE}/api/table/${tableName}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to fetch data');
+        return res.json();
+      })
+      .then((data) => {
+        let rows = [];
+        let cols = [];
+        if (Array.isArray(data)) {
+          cols = Object.keys(data[0] || {}).map((key) => ({
+            field: key,
+            headerName: key,
+            flex: 1,
+            editable: true,
+          }));
+          rows = data.map((row, idx) => ({ id: idx, ...row }));
+        } else if (data && data.rows && data.columns) {
+          cols = data.columns.map((c) => ({ ...c, editable: true }));
+          rows = data.rows.map((r, idx) => ({ id: idx, ...r }));
+        }
+        setRows(rows);
+        setColumns(cols);
+        setError(null);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [tableName]);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 60000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  const handleSave = () => {
+    const output = rows.map(({ id, ...rest }) => rest);
+    fetch(`${API_BASE}/api/table/${tableName}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(output),
+    }).catch((err) => setError(err.message));
+  };
+
+  const processRowUpdate = (newRow) => {
+    setRows((prev) => prev.map((r) => (r.id === newRow.id ? newRow : r)));
+    return newRow;
+  };
+
+  const handleFilterChange = (e) => setFilterText(e.target.value);
+
+  const filteredRows = rows.filter((row) =>
+    Object.values(row).some((val) =>
+      String(val).toLowerCase().includes(filterText.toLowerCase())
+    )
+  );
+
+  if (loading) return <CircularProgress />;
+  if (error) return <Alert severity="error">{error}</Alert>;
+
+  return (
+    <Box>
+      <Box mb={2} sx={{ display: 'flex', gap: 2 }}>
+        <TextField label="Search" value={filterText} onChange={handleFilterChange} />
+        <Button variant="contained" onClick={handleSave}>Save</Button>
+      </Box>
+      <div style={{ height: 400, width: '100%' }}>
+        <DataGrid
+          rows={filteredRows}
+          columns={columns}
+          pagination
+          pageSizeOptions={[5, 10, 20]}
+          processRowUpdate={processRowUpdate}
+          experimentalFeatures={{ newEditingApi: true }}
+        />
+      </div>
+    </Box>
+  );
+}

--- a/web/frontend/src/index.js
+++ b/web/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- introduce new React app under `web/frontend`
- implement DataGrid-based editing table
- add MUI-based tab interface
- containerize the frontend and expose it via docker-compose
- update README and gitignore

## Testing
- `npm --prefix web/frontend install` *(fails: 403 Forbidden)*
- `npm --prefix web/frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834e8f328c8323b2092771a8005f13