### PR TITLE
Fix API routing between frontend and backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
     build:
       context: ./web/frontend
       dockerfile: Dockerfile
+      args:
+        - REACT_APP_API_URL=http://backend:8080
     ports:
       - "3000:80"
-    environment:
-      - REACT_APP_API_URL=http://backend:8080
     depends_on:
       - backend
   s3:

--- a/web/frontend/Dockerfile
+++ b/web/frontend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine as build
 WORKDIR /app
+ARG REACT_APP_API_URL=http://backend:8080
+ENV REACT_APP_API_URL=${REACT_APP_API_URL}
 COPY package.json ./
 RUN npm install
 COPY public ./public
@@ -8,5 +10,5 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 3000
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- set build ARG for React to send requests to the Go backend
- expose port 80 from nginx
- pass REACT_APP_API_URL during image build via docker-compose

## Testing
- `go build ./...`
- `go vet ./...`
- `npm test --silent -- --passWithNoTests`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_68839b498bfc83238e780e5d12fa39db