### PR TITLE
Fix API URL config for browser access

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This project provides a React frontend and a Go backend that store and retrieve 
 ## Usage
 
 1. Copy `.env.example` to `.env` and adjust credentials if needed.
-2. Run `docker-compose up --build` to start the backend, frontend and MinIO services.
-3. Access the frontend at `http://localhost:3000`, the backend at `http://localhost:8080` and the MinIO console at `http://localhost:9001` (default credentials are from `.env`).
+2. Ensure `web/frontend/.env` contains `REACT_APP_API_URL=http://localhost:8080/api` so the browser can reach the backend.
+3. Run `docker-compose up --build` to start the backend, frontend and MinIO services.
+4. Access the frontend at `http://localhost:3000`, the backend at `http://localhost:8080` and the MinIO console at `http://localhost:9001` (default credentials are from `.env`).
 
 The backend exposes several endpoints under `/api`:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       context: ./web/frontend
       dockerfile: Dockerfile
       args:
-        - REACT_APP_API_URL=http://backend:8080
+        - REACT_APP_API_URL=http://localhost:8080/api
     ports:
       - "3000:80"
     depends_on:

--- a/web/backend/handlers/table.go
+++ b/web/backend/handlers/table.go
@@ -22,6 +22,7 @@ type TableHandler struct {
 
 // GetTabs lists available directories under the bucket
 func (h *TableHandler) GetTabs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	tabs := map[string]struct{}{}
 	for object := range h.Client.ListObjects(r.Context(), h.Bucket, minio.ListObjectsOptions{Recursive: true}) {
 		if object.Err != nil {
@@ -44,6 +45,7 @@ func (h *TableHandler) GetTabs(w http.ResponseWriter, r *http.Request) {
 
 // GetTable fetches the latest file for a given tab and returns JSON
 func (h *TableHandler) GetTable(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	tab := mux.Vars(r)["tab"]
 	prefix := tab + "/"
 	var latest minio.ObjectInfo
@@ -119,6 +121,7 @@ func (h *TableHandler) GetTable(w http.ResponseWriter, r *http.Request) {
 
 // PutTable uploads JSON data for a given tab
 func (h *TableHandler) PutTable(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	tab := mux.Vars(r)["tab"]
 	data, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/web/frontend/.env
+++ b/web/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8080/api

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { AppBar, Tabs, Tab, Box, Container } from '@mui/material';
 import TabPanel from './components/TabPanel';
 
-const API_BASE = process.env.REACT_APP_API_URL || '';
+const API_BASE = process.env.REACT_APP_API_URL || '/api';
 
 export default function App() {
   const [value, setValue] = useState(0);

--- a/web/frontend/src/components/TableView.jsx
+++ b/web/frontend/src/components/TableView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { DataGrid } from '@mui/x-data-grid';
 import { Box, Button, TextField, CircularProgress, Alert } from '@mui/material';
 
-const API_BASE = process.env.REACT_APP_API_URL || '';
+const API_BASE = process.env.REACT_APP_API_URL || '/api';
 
 export default function TableView({ tableName }) {
   const [rows, setRows] = useState([]);

--- a/web/frontend/src/setupProxy.js
+++ b/web/frontend/src/setupProxy.js
@@ -1,0 +1,8 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  app.use('/api', createProxyMiddleware({
+    target: 'http://backend:8080',
+    changeOrigin: true,
+  }));
+};


### PR DESCRIPTION
## Summary
- use `/api` as the fallback API base
- set the build arg to `http://localhost:8080/api`
- forward `/api` to the backend when developing
- allow CORS from the Go backend
- document new `.env` usage for frontend

## Testing
- `npm test --silent` *(fails: No tests found)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6887713b9790832390445913be7d2db5